### PR TITLE
use Module::Metadata to extract inner package list

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,7 @@ Archive::Any = 0.0932
 CPAN::Meta = 2.113640
 File::Temp = 0.22
 File::Find::Object = 0.2.3
-Module::Extract::Namespaces = 0.14
+Module::Metadata = 0
 DateTime::Format::Epoch = 0.13
 Dist::Metadata = 0.922
 

--- a/lib/Dist/Data.pm
+++ b/lib/Dist/Data.pm
@@ -6,7 +6,7 @@ use Archive::Any;
 use CPAN::Meta;
 use File::Temp;
 use File::Find::Object;
-use Module::Extract::Namespaces;
+use Module::Metadata;
 use DateTime::Format::Epoch::Unix;
 use Dist::Metadata ();
 
@@ -193,9 +193,10 @@ sub _build_namespaces {
 	for (keys %{$self->files}) {
 		my $key = $_;
 		if ($key =~ /\.pm$/ || $key =~ /\.pl$/) {
-			my @namespaces = Module::Extract::Namespaces->from_file($self->files->{$key});
+			my $metadata = Module::Metadata->new_from_file($self->files->{$key});
+			my @namespaces = $metadata->packages_inside;
 			for (@namespaces) {
-				next unless defined $_;
+				next unless defined $_ && $_ ne 'main';
 				$namespaces{$_} = [] unless defined $namespaces{$_};
 				push @{$namespaces{$_}}, $key;
 			}


### PR DESCRIPTION
Module::Metadata is in core and can provide the list of inner packages, so it can be used instead of Module::Extract::Namespaces.